### PR TITLE
example of receive message size update

### DIFF
--- a/DemoClient/DemoClient/App.config
+++ b/DemoClient/DemoClient/App.config
@@ -24,7 +24,8 @@
         <behavior name="ClientCertificateBehavior">
           <clientCredentials>
 			  <!-- <clientCertificate findValue="9b6b8e98309e53892435baab1d0b86c4f338a1df" storeLocation="CurrentUser" storeName="My" x509FindType="FindByThumbprint"/> -->
-			<clientCertificate findValue="6030c3bb8adf0492d2985cadd0babe66ea5b59ae" storeLocation="CurrentUser" storeName="My" x509FindType="FindByThumbprint"/>
+			<!--clientCertificate findValue="6030c3bb8adf0492d2985cadd0babe66ea5b59ae" storeLocation="CurrentUser" storeName="My" x509FindType="FindByThumbprint"/-->
+            <clientCertificate findValue="a82cea2b27edb5eb7dd4f43857fd70a6ac49160b" storeLocation="CurrentUser" storeName="My" x509FindType="FindByThumbprint"/>
           </clientCredentials>
         </behavior>
       </endpointBehaviors>

--- a/DemoTokenClient/Digst.OioIdws.LibBas/Bindings/LibBasBinding.cs
+++ b/DemoTokenClient/Digst.OioIdws.LibBas/Bindings/LibBasBinding.cs
@@ -26,6 +26,9 @@ namespace Digst.OioIdws.LibBas.Bindings
             var transport = new HttpsTransportBindingElement();
             transport.RequireClientCertificate = true;
 
+            // By default the received message size is limited to 65535 bytes, this can be overriden by setting this number parameter (in bytes)
+            transport.MaxReceivedMessageSize = 2097152;
+
             var encoding = new TextMessageEncodingBindingElement();
             // [LIB-BAS] requires SOAP 1.1 and WS-Adressing 1.0
             encoding.MessageVersion = MessageVersion.Soap11WSAddressing10;


### PR DESCRIPTION
- fixes client certificate thumbprint configuration for DemoClient
- adds explicit example how to override default maximum receive message size for custom binding in DemoTokenClient